### PR TITLE
[FEATURE] - Toggle Favorites

### DIFF
--- a/.idea/androidTestResultsUserPreferences.xml
+++ b/.idea/androidTestResultsUserPreferences.xml
@@ -3,6 +3,19 @@
   <component name="AndroidTestResultsUserPreferences">
     <option name="androidTestResultsTableState">
       <map>
+        <entry key="-656137909">
+          <value>
+            <AndroidTestResultsTableState>
+              <option name="preferredColumnWidths">
+                <map>
+                  <entry key="Duration" value="90" />
+                  <entry key="Medium_Phone_API_36.0" value="120" />
+                  <entry key="Tests" value="360" />
+                </map>
+              </option>
+            </AndroidTestResultsTableState>
+          </value>
+        </entry>
         <entry key="560250986">
           <value>
             <AndroidTestResultsTableState>

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -5,6 +5,9 @@
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
       </SelectionState>
+      <SelectionState runConfigName="FavoritesDataStoreTest">
+        <option name="selectionMode" value="DROPDOWN" />
+      </SelectionState>
     </selectionStates>
   </component>
 </project>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -77,4 +77,7 @@ dependencies {
     // Debug
     debugImplementation(libs.androidx.ui.tooling)
     debugImplementation(libs.androidx.ui.test.manifest)
+
+    // Libs
+    implementation(libs.datastore)
 }

--- a/app/src/androidTest/java/com/example/countryfinder/data/favorites/FavoritesDataStoreTest.kt
+++ b/app/src/androidTest/java/com/example/countryfinder/data/favorites/FavoritesDataStoreTest.kt
@@ -49,18 +49,24 @@ class FavoritesDataStoreTest {
 
     @Test
     fun initiallyFavoritesIsEmpty() = runTest {
+        // With
         val currentFavorites = store.favoritesFlow.first()
+
+        // Assert
         assertTrue(currentFavorites.isEmpty())
     }
 
     @Test
     fun toggleFavoriteAddsThenRemovesCityId() = runTest {
+        // With
         val id = 123L
 
+        // Do
         store.toggle(id)
         var currentFavorites = store.favoritesFlow.first()
         assertTrue(id.toString() in currentFavorites)
 
+        // Assert
         store.toggle(id)
         currentFavorites = store.favoritesFlow.first()
         assertFalse(id.toString() in currentFavorites)
@@ -68,26 +74,33 @@ class FavoritesDataStoreTest {
 
     @Test
     fun toggleFavoriteSupportsMultipleCityIds() = runTest {
+        // With
         val ids = listOf(1L, 2L, 3L, 10L, 42L)
         ids.forEach { store.toggle(it) }
 
+        // Do
         val currentFavorites = store.favoritesFlow.first()
         assertEquals(ids.map { it.toString() }.toSet(), currentFavorites)
 
         // Remove one and check
         store.toggle(10L)
         val afterFavorites = store.favoritesFlow.first()
+
+        // Assert
         assertEquals(ids.filter { it != 10L }.map { it.toString() }.toSet(), afterFavorites)
     }
 
     @Test
     fun toggleFavoritePersistOnRecreation() = runTest {
+        // With
         store.toggle(7L)
         store.toggle(8L)
 
-        // "Recreate" the dataStore, not another instance. We wrap the same intern instance
+        // Do
         val newDataStore = FavoritesDataStore(context)
         val currentFavorites = newDataStore.favoritesFlow.first()
+
+        // Assert
         assertTrue("7" in currentFavorites && "8" in currentFavorites)
     }
 }

--- a/app/src/androidTest/java/com/example/countryfinder/data/favorites/FavoritesDataStoreTest.kt
+++ b/app/src/androidTest/java/com/example/countryfinder/data/favorites/FavoritesDataStoreTest.kt
@@ -1,0 +1,93 @@
+package com.example.countryfinder.data.favorites
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+@OptIn(ExperimentalCoroutinesApi::class)
+class FavoritesDataStoreTest {
+
+    private lateinit var context: Context
+    private lateinit var store: FavoritesDataStore
+
+    @Before
+    fun setUp() = runTest {
+        context = ApplicationProvider.getApplicationContext()
+        store = FavoritesDataStore(context)
+
+        // TODO: Emprolijar esto, hay que limpiar el DataStore antes de cada test para evitar Exception de instancias repetidas y arrastrar el estado
+        clearFavorites()
+    }
+
+    @After
+    fun tearDown() = runTest {
+        clearFavorites()
+    }
+
+    private suspend fun clearFavorites() {
+        val currentFavorites = store.favoritesFlow.first()
+        if (currentFavorites.isNotEmpty()) {
+            // For every toggled id > remove
+            currentFavorites.forEach { idStr ->
+                idStr.toLongOrNull()?.let { store.toggle(it) }
+            }
+            // Check if empty
+            assertTrue(store.favoritesFlow.first().isEmpty())
+        }
+    }
+
+    @Test
+    fun initiallyFavoritesIsEmpty() = runTest {
+        val currentFavorites = store.favoritesFlow.first()
+        assertTrue(currentFavorites.isEmpty())
+    }
+
+    @Test
+    fun toggleFavoriteAddsThenRemovesCityId() = runTest {
+        val id = 123L
+
+        store.toggle(id)
+        var currentFavorites = store.favoritesFlow.first()
+        assertTrue(id.toString() in currentFavorites)
+
+        store.toggle(id)
+        currentFavorites = store.favoritesFlow.first()
+        assertFalse(id.toString() in currentFavorites)
+    }
+
+    @Test
+    fun toggleFavoriteSupportsMultipleCityIds() = runTest {
+        val ids = listOf(1L, 2L, 3L, 10L, 42L)
+        ids.forEach { store.toggle(it) }
+
+        val currentFavorites = store.favoritesFlow.first()
+        assertEquals(ids.map { it.toString() }.toSet(), currentFavorites)
+
+        // Remove one and check
+        store.toggle(10L)
+        val afterFavorites = store.favoritesFlow.first()
+        assertEquals(ids.filter { it != 10L }.map { it.toString() }.toSet(), afterFavorites)
+    }
+
+    @Test
+    fun toggleFavoritePersistOnRecreation() = runTest {
+        store.toggle(7L)
+        store.toggle(8L)
+
+        // "Recreate" the dataStore, not another instance. We wrap the same intern instance
+        val newDataStore = FavoritesDataStore(context)
+        val currentFavorites = newDataStore.favoritesFlow.first()
+        assertTrue("7" in currentFavorites && "8" in currentFavorites)
+    }
+}

--- a/app/src/main/java/com/example/countryfinder/data/favorites/FavoritesDataStore.kt
+++ b/app/src/main/java/com/example/countryfinder/data/favorites/FavoritesDataStore.kt
@@ -1,0 +1,27 @@
+package com.example.countryfinder.data.favorites
+
+import android.content.Context
+import androidx.datastore.preferences.core.*
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.flow.map
+
+private val Context.dataStore by preferencesDataStore("favorites")
+
+/**
+ * Class that handles saving favorites cities in DataStore
+ */
+class FavoritesDataStore(private val context: Context) {
+    private val KEY_IDS = stringSetPreferencesKey("fav_ids")
+
+    val favoritesFlow = context.dataStore.data.map { prefs ->
+        prefs[KEY_IDS] ?: emptySet()
+    }
+
+    suspend fun toggle(id: Long) {
+        context.dataStore.edit { prefs ->
+            val set = prefs[KEY_IDS]?.toMutableSet() ?: mutableSetOf()
+            if (!set.add(id.toString())) set.remove(id.toString())
+            prefs[KEY_IDS] = set
+        }
+    }
+}

--- a/app/src/test/java/com/example/countryfinder/presentation/viewmodel/CityListViewModelTest.kt
+++ b/app/src/test/java/com/example/countryfinder/presentation/viewmodel/CityListViewModelTest.kt
@@ -8,6 +8,7 @@ import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceTimeBy
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -54,10 +55,14 @@ class CityListViewModelTest {
         City("AU", "Sydney", 5, CityCoordinates(lon = 0.0, lat = 0.0)),
     )
 
-    private fun createViewModelWithSeedCities(): CityListViewModel {
+    private fun createViewModelWithSeedCities(favsFlow: MutableSharedFlow<Set<String>>? = null): CityListViewModel {
         coEvery { repository.getCities() } returns citiesSeed()
-        return CityListViewModel(repository, ioDispatcher = testDispatcher)
+        val viewModel = CityListViewModel(repository, ioDispatcher = testDispatcher)
+        if (favsFlow != null) viewModel.attachFavorites(favsFlow)
+        return viewModel
     }
+
+    private fun names(vm: CityListViewModel) = vm.cities.value.map { it.name }
 
     @Test
     fun `Initial ViewModel load groups by asc city and asc country`() = runTest {
@@ -210,5 +215,66 @@ class CityListViewModelTest {
         assertEquals("Buenos Aires", viewModel.cities.value.first().name)
         assertNull(viewModel.error.value)
         coVerify(exactly = 2) { repository.getCities() }
+    }
+
+    @Test
+    fun `ony favorites toggles filter by ids`() = runTest {
+        // With
+        val favsFlow = MutableSharedFlow<Set<String>>(replay = 0, extraBufferCapacity = 1)
+        val viewModel = createViewModelWithSeedCities(favsFlow)
+        advanceUntilIdle() // finish load()
+
+        // Emit favorites (ids as String)
+        favsFlow.tryEmit(setOf("2", "5")) // Albuquerque, Sydney
+        advanceUntilIdle()
+
+        // Do
+        viewModel.toggleOnlyFavorites()
+        advanceUntilIdle()
+
+        // Assert
+        assertEquals(listOf("Albuquerque", "Sydney"), names(viewModel))
+    }
+
+    @Test
+    fun `changing favorites recomputes list when only favorites is toggle`() = runTest {
+        // With
+        val favsFlow = MutableSharedFlow<Set<String>>(replay = 0, extraBufferCapacity = 2)
+        val viewModel = createViewModelWithSeedCities(favsFlow)
+        advanceUntilIdle()
+
+        // Do
+        viewModel.toggleOnlyFavorites()
+        advanceUntilIdle()
+        favsFlow.tryEmit(setOf("2", "5"))
+        advanceUntilIdle()
+        assertEquals(listOf("Albuquerque", "Sydney"), names(viewModel))
+
+        // Assert
+        favsFlow.tryEmit(setOf("1"))
+        advanceUntilIdle()
+        assertEquals(listOf("Alabama"), names(viewModel))
+    }
+
+    @Test
+    fun `prefix and only favorites combines filter`() = runTest {
+        // With
+        val favsFlow = MutableSharedFlow<Set<String>>(replay = 0, extraBufferCapacity = 1)
+        val vm = createViewModelWithSeedCities(favsFlow)
+        advanceUntilIdle()
+
+        // Do
+        favsFlow.tryEmit(setOf("1", "3", "5"))
+        advanceUntilIdle()
+        vm.onQueryChange("A")
+        advanceTimeBy(200)
+        advanceUntilIdle()
+
+        // Toggle favorites, remains Alabama(1) y Anaheim(3)
+        vm.toggleOnlyFavorites()
+        advanceUntilIdle()
+
+        // Assert
+        assertEquals(listOf("Alabama", "Anaheim"), names(vm))
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ mockwebserver = "5.1.0"
 retrofit = "3.0.0"
 mockk = "1.14.5"
 coroutinesTest = "1.10.2"
+datastore = "1.1.7"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -35,6 +36,7 @@ retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit
 retrofit-converter-gson = { module = "com.squareup.retrofit2:converter-gson", version.ref = "retrofit" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutinesTest" }
+datastore = { module = "androidx.datastore:datastore-preferences", version.ref ="datastore"}
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
**Context**
- We want to be able to add cities to favorites and filter favorites between our city list

**Solution**
- We create a "favorites only" switch to show only the cities that we marked
- We create a favorites button in every city row, to add that city to favorites

**Changes**
- Created `FavoritesDataStore`, a class that handles saving favorite cities in Android DataStore
- Created "favorites only `Switch` for display only favorite cities
- Created `favs` StateFlow in ViewModel for updating the city list on favorites
- Created tests

**Screens**


https://github.com/user-attachments/assets/fc9fc126-8ece-490f-acb1-350dd9e179d4







